### PR TITLE
Feat #3: Add drag-and-drop layout reordering using Swapy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "@vercel/analytics": "^1.5.0",
         "lucide-react": "^0.344.0",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "swapy": "^1.0.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.9.1",
@@ -3749,6 +3750,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/swapy": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/swapy/-/swapy-1.0.5.tgz",
+      "integrity": "sha512-XEzy5HCw7yESb7QajKTBJ+NA/BL0kAKlE7XhSMPZawF740X4ws/5CFtXRsVDQ+EztISC759a9+DJM9mxjz4hXg==",
+      "license": "GPL-3.0"
     },
     "node_modules/tailwindcss": {
       "version": "3.4.17",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "@vercel/analytics": "^1.5.0",
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "swapy": "^1.0.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState, useEffect, useRef} from 'react';
 import PieChartToday from './components/PieChartToday';
 import DaysLeftWeek from './components/DaysLeftWeek';
 import MonthsLeftYear from './components/MonthsLeftYear';
@@ -9,6 +9,8 @@ import GoalTracker from './components/GoalTracker';
 import { useLocalStorage } from './hooks/useLocalStorage';
 import GitHubButton from './components/GithubButton';
 import logo from "./public/timeleft.png"
+import { Swapy } from 'swapy';
+import { createSwapy } from 'swapy';
 
 interface Goal {
   id: string;
@@ -20,6 +22,26 @@ interface Goal {
 function App() {
   const [goals, setGoals] = useLocalStorage<Goal[]>('timeleft-goals', []);
   const [selectedDate, setSelectedDate] = useState<string | undefined>();
+
+  const swapyRef = useRef<Swapy | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+  if (containerRef.current) {
+    swapyRef.current = createSwapy(containerRef.current, {
+      swapMode: 'hover',
+      autoScrollOnDrag: true,
+      animation: 'spring',
+    })
+  }
+
+  return () => {
+    if (swapyRef.current) {
+      swapyRef.current.destroy()
+      swapyRef.current = null
+    }
+  }
+}, [])
 
   const handleGoalAdd = (goal: Omit<Goal, 'id'>) => {
     const newGoal: Goal = {
@@ -39,7 +61,7 @@ function App() {
 
   return (
 
-    <div className="flex overflow-hidden flex-col min-h-screen bg-black text-white p-4">
+    <div className="flex overflow-y-auto flex-col min-h-screen bg-black text-white p-4">
       {/* Header */}
       <header className="flex justify-between items-center pt-1  pb-4 pr-4">
         <div className='flex flex-row gap-2 justify-center items-center'>
@@ -51,43 +73,57 @@ function App() {
 
       {/* Main Grid - fills available space */}
       <div className="flex-1 flex flex-col">
-        <div className="flex-1 grid grid-cols-1 lg:grid-cols-12 gap-y-0">
+        <div className="flex-1 grid grid-cols-1 lg:grid-cols-12 gap-y-0" ref={containerRef}>
           {/* Top Row - Time Visualization */}
           <div className="flex-1 lg:col-span-12 grid grid-cols-1 md:grid-cols-3">
-            <div className="border-2 border-b-0 md:border-r-0 border-dashed border-gray-700 h-full">
-              <PieChartToday />
+            <div className="border-2 border-b-0 md:border-r-0 border-dashed border-gray-700 h-full" data-swapy-slot="pie">
+              <div data-swapy-item="pie" className="h-full w-full">
+                <PieChartToday />
+              </div>
             </div>
-            <div className="border-2 border-b-0 md:border-r-0 border-dashed border-gray-700 h-full">
-              <DaysLeftWeek />
+            <div className="border-2 border-b-0 md:border-r-0 border-dashed border-gray-700 h-full" data-swapy-slot="week">
+              <div data-swapy-item="week" className="h-full w-full">
+                <DaysLeftWeek />
+              </div>
             </div>
-            <div className="border-2 border-b-0 border-dashed border-gray-700 h-full">
-              <MonthsLeftYear />
+            <div className="border-2 border-b-0 border-dashed border-gray-700 h-full" data-swapy-slot="months">
+              <div data-swapy-item="months" className="h-full w-full">
+                <MonthsLeftYear />
+              </div>
             </div>
           </div>
           {/* Middle Row - Metrics and Clock */}
           <div className="flex-1 lg:col-span-12 grid grid-cols-1 md:grid-cols-2">
-            <div className="border-2 border-b-0 md:border-r-0 border-dashed border-gray-700 h-full">
-              <MotivationalMetrics />
+            <div className="border-2 border-b-0 md:border-r-0 border-dashed border-gray-700 h-full" data-swapy-slot="metric">
+              <div data-swapy-item="metric" className="h-full w-full">
+                <MotivationalMetrics />
+              </div>
             </div>
-            <div className="border-2 border-b-0 border-dashed border-gray-700 h-full">
-              <DotMatrixClock />
+            <div className="border-2 border-b-0 border-dashed border-gray-700 h-full" data-swapy-slot="clock">
+              <div data-swapy-item="clock" className="h-full w-full">
+                <DotMatrixClock />
+              </div>
             </div>
           </div>
           {/* Bottom Row - Year Grid and Goals */}
           <div className="flex-1 lg:col-span-12 grid grid-cols-1 md:grid-cols-2">
-            <div className="border-2 border-b-0 md:border-b-2 md:border-r-0 border-dashed border-gray-700 h-full">
-              <YearlyDotsGrid 
+            <div className="border-2 border-b-0 md:border-b-2 md:border-r-0 border-dashed border-gray-700 h-full" data-swapy-slot="yearly">
+              <div data-swapy-item="yearly" className="h-full w-full">
+                <YearlyDotsGrid 
                 goals={goals} 
                 onDayClick={handleDayClick}
               />
+              </div>
             </div>
-            <div className="border-2 border-dashed border-gray-700 h-full">
-              <GoalTracker 
+            <div className="border-2 border-dashed border-gray-700 h-full" data-swapy-slot="goals">
+              <div data-swapy-item="goals" className="h-full w-full">
+                <GoalTracker 
                 goals={goals}
                 onGoalAdd={handleGoalAdd}
                 onGoalRemove={handleGoalRemove}
                 selectedDate={selectedDate}
               />
+              </div>
             </div>
           </div>
         </div>

--- a/src/index.css
+++ b/src/index.css
@@ -4,7 +4,7 @@
 
 @media (min-width: 900px) {
   html, body {
-    overflow: hidden;
+    overflow-x: hidden;
     height: 100%;
   }
 }


### PR DESCRIPTION
Added drag-and-drop support for rearranging the layout using Swapy. This lets users move components around freely on the page.

Also fixed the issue where the footer and bottom row weren’t visible by tweaking the CSS, added a scrollbar so the full layout is always accessible.